### PR TITLE
Add hint to support plugin

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,5 +26,6 @@ Windows, Mac or Linux? Chrome, Firefox or IE? What versions?
 #### Log of the bug
 
 Please remember to check for any sensible information in any logs you provide like repository names!
+Consider to use the [support plugin](https://scm-manager.org/plugins/scm-support-plugin/) to easily create trace logs.
 
 #### Further information like screenshots


### PR DESCRIPTION
## Proposed changes

Adds hint to use the support plugin to easily access trace logs. 
